### PR TITLE
misc fixes and tweaks

### DIFF
--- a/crafting.lua
+++ b/crafting.lua
@@ -58,7 +58,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "digiline_routing:filter 2",
+	output = "digiline_routing:filter",
 	recipe = {
 		{steel, silver_wire, steel},
 		{connector, silicon, connector},
@@ -67,7 +67,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "digiline_routing:splitter 2",
+	output = "digiline_routing:splitter",
 	recipe = {
 		{connector, ""},
 		{silicon, connector},

--- a/crafting.lua
+++ b/crafting.lua
@@ -51,14 +51,14 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "digiline_routing:diode",
+	output = "digiline_routing:diode 2",
 	recipe = {
 		{connector, silicon, connector},
 	}
 })
 
 minetest.register_craft({
-	output = "digiline_routing:filter",
+	output = "digiline_routing:filter 2",
 	recipe = {
 		{steel, silver_wire, steel},
 		{connector, silicon, connector},
@@ -67,7 +67,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "digiline_routing:splitter",
+	output = "digiline_routing:splitter 2",
 	recipe = {
 		{connector, ""},
 		{silicon, connector},

--- a/crafting.lua
+++ b/crafting.lua
@@ -51,7 +51,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = "digiline_routing:diode 2",
+	output = "digiline_routing:diode",
 	recipe = {
 		{connector, silicon, connector},
 	}

--- a/filter.lua
+++ b/filter.lua
@@ -26,7 +26,7 @@ local function filter_init(pos)
 end
 
 local function filter_receive_fields(pos, formname, fields, sender)
-	if minetest.is_protected(pos, sender) and not minetest.check_player_privs(sender, "protection_bypass") then
+	if minetest.is_protected(pos, sender:get_player_name()) and not minetest.check_player_privs(sender, "protection_bypass") then
 		minetest.record_protection_violation(pos, sender)
 		return
 	end

--- a/multiblock.lua
+++ b/multiblock.lua
@@ -89,7 +89,7 @@ digiline_routing.multiblock.dig2 = function(pos, node)
 	removing_head = true
 	local dir = minetest.facedir_to_dir(node.param2)
 	local tail = vector.add(pos, dir)
-	minetest.dig_node(tail)
+	minetest.remove_node(tail)
 	removing_head = false
 end
 
@@ -97,6 +97,6 @@ digiline_routing.multiblock.dig2b = function(pos, node)
 	local dir = minetest.facedir_to_dir(node.param2)
 	local head = vector.subtract(pos, dir)
 	if not removing_head then
-		minetest.dig_node(head)
+		minetest.remove_node(head)
 	end
 end


### PR DESCRIPTION
crafting.lua: Doubled the output of the crafts, I can undo if you wish.
filter.lua: Fixed crash when using newer protector mod.
multiblock.lua: minetest.dig_node() wasn't working, so I replaced it with minetest.remove_node() and it works fine.