### PR TITLE
Prevent breakage of multinode devices

### DIFF
--- a/filter.lua
+++ b/filter.lua
@@ -115,6 +115,7 @@ minetest.register_node("digiline_routing:filter", {
 		},
 	},
 })
+mesecon.register_mvps_stopper("digiline_routing:filter")
 
 minetest.register_node("digiline_routing:filter_b", {
 	description = "<<INTERNAL>> Digiline Filter (Part B)",
@@ -144,3 +145,4 @@ minetest.register_node("digiline_routing:filter_b", {
 		},
 	},
 })
+mesecon.register_mvps_stopper("digiline_routing:filter_b")

--- a/multiblock.lua
+++ b/multiblock.lua
@@ -5,11 +5,14 @@ digiline_routing.multiblock = {}
 
 digiline_routing.multiblock.build2 = function(node1, node2, itemstack, placer, pointed_thing)
 	local under = pointed_thing.under
+	local above = pointed_thing.above
 	local pos
 	if minetest.registered_items[minetest.get_node(under).name].buildable_to then
 		pos = under
+	elseif minetest.registered_items[minetest.get_node(above).name].buildable_to then
+		pos = above
 	else
-		pos = pointed_thing.above
+		return itemstack, false
 	end
 
 	if digiline_routing.is_protected(pos, placer) then

--- a/splitter.lua
+++ b/splitter.lua
@@ -84,6 +84,7 @@ minetest.register_node("digiline_routing:splitter", {
 		},
 	},
 })
+mesecon.register_mvps_stopper("digiline_routing:splitter")
 
 minetest.register_node("digiline_routing:splitter_b", {
 	description = "<<INTERNAL>> Digiline Splitter (Part B)",
@@ -113,3 +114,4 @@ minetest.register_node("digiline_routing:splitter_b", {
 		},
 	},
 })
+mesecon.register_mvps_stopper("digiline_routing:splitter_b")


### PR DESCRIPTION
Pistons and movestones could damage multinode devices pushing single node only, including pushing into another device. Also a multinode device could be placed into any non-full node, buildable_to was ignored (for master node only).

Fixes: #7