### PR TITLE
Destroy modules also if area is protected(using minetest.remove_node)

### DIFF
--- a/diode.lua
+++ b/diode.lua
@@ -18,7 +18,7 @@ end
 local function diode_action(pos, node, channel, msg)
 	if digiline_routing.overheat.heat(pos) > OVERLOAD_THRESHOLD then
 		digiline_routing.overheat.forget(pos)
-		minetest.dig_node(pos)
+		minetest.remove_node(pos)
 		minetest.add_item(pos, node.name)
 		return
 	end

--- a/filter.lua
+++ b/filter.lua
@@ -46,9 +46,10 @@ local function filter_cleanup(pos, node)
 	digiline_routing.multiblock.dig2(pos, node)
 end
 
-local function filter_test(master, channel)
+local function filter_test(master, channel, node)
 	if digiline_routing.overheat.heat(master) > OVERLOAD_THRESHOLD then
-		minetest.dig_node(master)
+		minetest.remove_node(master)
+		filter_cleanup(master, node)
 		minetest.add_item(master, "digiline_routing:filter")
 		return false
 	end
@@ -56,7 +57,7 @@ local function filter_test(master, channel)
 end
 
 local function filter_in_action(pos, node, channel, msg)
-	if filter_test(pos, channel) then
+	if filter_test(pos, channel, node) then
 		local off = minetest.facedir_to_dir(node.param2)
 		local slave = vector.add(pos, off)
 		digiline:receptor_send(slave, filter_rules_out(node), channel, msg)
@@ -66,7 +67,7 @@ end
 local function filter_out_action(pos, node, channel, msg)
 	local off = minetest.facedir_to_dir(node.param2)
 	local master = vector.subtract(pos, off)
-	if filter_test(master, channel) then
+	if filter_test(master, channel, node) then
 		digiline:receptor_send(master, filter_rules_in(node), channel, msg)
 	end
 end

--- a/splitter.lua
+++ b/splitter.lua
@@ -27,7 +27,8 @@ end
 
 local function splitter_in_action(pos, node, channel, msg)
 	if digiline_routing.overheat.heat(pos) > OVERLOAD_THRESHOLD then
-		minetest.dig_node(pos)
+		minetest.remove_node(pos)
+		splitter_cleanup(pos, node)
 		minetest.add_item(pos, "digiline_routing:splitter")
 		return
 	end
@@ -40,7 +41,8 @@ local function splitter_out_action(pos, node, channel, msg)
 	local off = minetest.facedir_to_dir(node.param2)
 	local master = vector.subtract(pos, off)
 	if digiline_routing.overheat.heat(master) > OVERLOAD_THRESHOLD then
-		minetest.dig_node(master)
+		minetest.remove_node(master)
+		splitter_cleanup(master, node)
 		minetest.add_item(master, "digiline_routing:splitter")
 		return
 	end


### PR DESCRIPTION
Otherwise the nodes only drop and doesn't disappear and you get a overflow.
Related/Fixes:
https://github.com/pandorabox-io/pandorabox.io/issues/516
https://github.com/pandorabox-io/pandorabox.io/issues/515