### PR TITLE
add checks before node removal

### DIFF
--- a/multiblock.lua
+++ b/multiblock.lua
@@ -83,6 +83,17 @@ end
 digiline_routing.multiblock.dig2 = function(pos, node)
 	local dir = minetest.facedir_to_dir(node.param2)
 	local tail = vector.add(pos, dir)
+	local node2 = minetest.get_node_or_nil(tail)
+	if node2 then
+		local name2 = node2.name
+		if "air" ~= name2
+			and "vacuum:vacuum" ~= name2
+			and "planet_mars:airlight" ~= name2
+		then
+			-- abort, don't delete nodes
+			return
+		end
+	end
 	minetest.remove_node(tail)
 	digiline:update_autoconnect(tail)
 end

--- a/multiblock.lua
+++ b/multiblock.lua
@@ -81,7 +81,7 @@ digiline_routing.multiblock.rotate2b = function(pos, node, user, mode, new_param
 	return false
 end
 
-digiline_routing.partner_pos_or_nil = function(pos, node)
+digiline_routing.tail_pos_or_nil = function(pos, node)
 	local dirs = {
 		{ x = -1,z = 0},
 		{ x = 1, z = 0},
@@ -110,13 +110,13 @@ digiline_routing.partner_pos_or_nil = function(pos, node)
 end
 
 digiline_routing.multiblock.dig2 = function(pos, node)
-	local pos_tail = digiline_routing.partner_pos_or_nil(pos, node)
+	local tail_pos = digiline_routing.tail_pos_or_nil(pos, node)
 
 	-- nothing we can do if partner was not found
-	if not pos_tail then return end
+	if not tail_pos then return end
 
-	minetest.remove_node(pos_tail)
-	digiline:update_autoconnect(pos_tail)
+	minetest.remove_node(tail_pos)
+	digiline:update_autoconnect(tail_pos)
 end
 
 digiline_routing.multiblock.dig2b = function(pos, node, digger)


### PR DESCRIPTION
With sonic screwdriver filters can be rotated so they occupy a protected node.
It's bad enough when you delete your lua controller this way, but it also allows griefing of protected nodes.

This may not be the most elegant solution, but it seems to work.